### PR TITLE
Add an EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[bin/*]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.toml]
+indent_size = 4
+indent_style = space
+
+[*.rs]
+max_line_length = 100
+
+[*.{yml,yaml}]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
EditorConfig [^1] is a project that provides a common standard to configure many IDEs and editors through a shared configuration file. The goal is to help developers use a consistent coding style by configuring their tools in the same way.

An EditorConfig with a few sensible defaults has been added to the repository. The most controversial choice is probably the strict 80 line length, which is a personal preference.