### PR TITLE
Set up pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# pre-commit configuration
+#
+# We use pre-commit to enforce a consistency in our repositories. By default,
+# YAML and Markdown files get linted, and Prettier runs to auto-format the file
+# types it supports. Depending on the project, other rules can be added here to
+# support the needs of the project.
+#
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: check-case-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]


### PR DESCRIPTION
I make heavy use of pre-commit hooks to catch common errors before they are pushed to a remote repository. By default, I run linters and code formatters locally on each commit using the pre-commit [^1] tool.

The initial pre-commit hooks feature a general checks that ensure consistency across operating systems.

[^1]: https://pre-commit.com/