### PR TITLE
Lint YAML files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,10 @@ repos:
     rev: v0.32.2
     hooks:
       - id: markdownlint
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.28.0
+    hooks:
+      - id: yamllint
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0-alpha.4
     hooks:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  line-length:
+    ignore: |
+      .github/workflows/*


### PR DESCRIPTION
 YAML files are linted automatically by a pre-commit hook before they
are committed to the repository. The default configuration file disables the line-length rule for GitHub Action workflows, since they often contain very long identifiers.