### PR TITLE
Add GitHub Actions workflows

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,0 +1,12 @@
+---
+name: GitHub
+
+"on":
+  push:
+    branches:
+      - main
+
+jobs:
+  labels:
+    name: Labels
+    uses: jdno/workflows/.github/workflows/sync-labels.yml@main

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -1,0 +1,17 @@
+---
+name: JSON
+
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - "**.json"
+  pull_request:
+    paths:
+      - "**.json"
+
+jobs:
+  style:
+    name: Style
+    uses: jdno/workflows/.github/workflows/json-style.yml@main

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,21 @@
+---
+name: Markdown
+
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - "**.md"
+  pull_request:
+    paths:
+      - "**.md"
+
+jobs:
+  lint:
+    name: Lint
+    uses: jdno/workflows/.github/workflows/markdown-lint.yml@main
+
+  style:
+    name: Style
+    uses: jdno/workflows/.github/workflows/markdown-style.yml@main

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,27 @@
+---
+name: Rust
+
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - "**.rs"
+      - "**.toml"
+  pull_request:
+    paths:
+      - "**.rs"
+      - "**.toml"
+
+jobs:
+  lint:
+    name: Lint
+    uses: jdno/workflows/.github/workflows/rust-lint.yml@main
+
+  style:
+    name: Style
+    uses: jdno/workflows/.github/workflows/rust-style.yml@main
+
+  test:
+    name: Test
+    uses: jdno/workflows/.github/workflows/rust-test.yml@main

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,0 +1,21 @@
+---
+name: Shell
+
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - "**.sh"
+  pull_request:
+    paths:
+      - "**.sh"
+
+jobs:
+  lint:
+    name: Lint
+    uses: jdno/workflows/.github/workflows/shell-lint.yml@main
+
+  style:
+    name: Style
+    uses: jdno/workflows/.github/workflows/shell-style.yml@main

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -1,0 +1,23 @@
+---
+name: YAML
+
+"on":
+  push:
+    branches:
+      - main
+    paths:
+      - "**.yml"
+      - "**.yaml"
+  pull_request:
+    paths:
+      - "**.yml"
+      - "**.yaml"
+
+jobs:
+  lint:
+    name: Lint
+    uses: jdno/workflows/.github/workflows/yaml-lint.yml@main
+
+  style:
+    name: Style
+    uses: jdno/workflows/.github/workflows/yaml-style.yml@main


### PR DESCRIPTION
A default set of workflows has been added to our GitHub Actions setup. The workflows make heavy use of path filters to run only the checks that are required. This makes it possible to copy them into every repository and optimizes the build times on pull requests.