### PR TITLE
Configure auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+---
+changelog:
+  exclude:
+    labels:
+      - R-ignore
+  categories:
+    - title: Security
+      labels:
+        - R-security
+    - title: Added
+      labels:
+        - R-added
+    - title: Changed
+      labels:
+        - R-changed
+    - title: Deprecated
+      labels:
+        - R-deprecated
+    - title: Removed
+      labels:
+        - R-removed
+    - title: Fixed
+      labels:
+        - R-fixed


### PR DESCRIPTION
GitHub has a feature to generate release notes from pull requests. We have already created issue labels that can be used to add items to the change log. This configuration files maps these labels to section in the release notes.