### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":disableDependencyDashboard"],
-  "semanticCommits": "disabled"
+
+  "pre-commit": {
+    "enabled": true
+  },
+  "semanticCommits": "disabled",
+
+  "assignees": ["jdno"],
+  "reviewers": ["jdno"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Cache for Prettier 4
+.prettiercache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=1024"]
@@ -19,14 +19,15 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.32.2
+    rev: v0.39.0
     hooks:
       - id: markdownlint
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.28.0
+    rev: v1.33.0
     hooks:
       - id: yamllint
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
+        args: ["--cache-location=.prettiercache"]


### PR DESCRIPTION
The pre-commit hooks have been updated to their latest version, and Renovate has been configured to keep them up-to-date going forward.